### PR TITLE
Fix "The notification "The address was copied to clipboard" does not appear (Bitcoin network)"

### DIFF
--- a/p2p_wallet/Scenes/Main/ReceiveToken/Bitcoin/ReceiveToken.ReceiveBitcoinViewModel.swift
+++ b/p2p_wallet/Scenes/Main/ReceiveToken/Bitcoin/ReceiveToken.ReceiveBitcoinViewModel.swift
@@ -162,6 +162,7 @@ extension ReceiveToken.ReceiveBitcoinViewModel: ReceiveTokenBitcoinViewModelType
     func copyToClipboard() {
         guard let address = renVMService.getCurrentAddress() else { return }
         clipboardManager.copyToClipboard(address)
+        notificationsService.showInAppNotification(.done(L10n.addressCopiedToClipboard))
         analyticsManager.log(event: .receiveAddressCopied)
     }
     


### PR DESCRIPTION
## Link jirra to issue
https://p2pvalidator.atlassian.net/browse/P2PW-1272

## Description of the changes
- 
