### PR TITLE
feat: change default grouping separator to user's default Localize

### DIFF
--- a/p2p_wallet/Extensions/Double+Extensions.swift
+++ b/p2p_wallet/Extensions/Double+Extensions.swift
@@ -74,7 +74,7 @@ extension Double {
         maximumFractionDigits: Int = 3,
         showPlus: Bool = false,
         showMinus: Bool = true,
-        groupingSeparator: String? = " ",
+        groupingSeparator: String? = nil,
         autoSetMaximumFractionDigits: Bool = false
     ) -> String {
         let formatter = NumberFormatter()


### PR DESCRIPTION
## Link jirra to issue
https://p2pvalidator.atlassian.net/browse/PWN-1593

## Description of the changes
- Change the default grouping separator to current user's default
- For example: in US market, the number would be 1,345.12, in Russian market, the number  would be 1.345,12