### PR TITLE
[Swap settings] When clicking on the Custom button in the Max price slippage block, immediately focus on the input field and open the keyboard

### DIFF
--- a/p2p_wallet/Base.lproj/LaunchScreen.storyboard
+++ b/p2p_wallet/Base.lproj/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,6 +22,7 @@
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="p-logo" translatesAutoresizingMaskIntoConstraints="NO" id="xqn-Zd-f0w">
                                 <rect key="frame" x="98.5" y="366" width="217" height="164"/>
+                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="217" id="jiE-Kz-bbm"/>
                                     <constraint firstAttribute="height" constant="164" id="va9-KN-nUZ"/>

--- a/p2p_wallet/Scenes/Main/SwapToken/Settings/Subviews/SwapTokenSettings.CustomSlippageField.swift
+++ b/p2p_wallet/Scenes/Main/SwapToken/Settings/Subviews/SwapTokenSettings.CustomSlippageField.swift
@@ -46,6 +46,14 @@ extension SwapTokenSettings {
         func setText(_ text: String) {
             textField.text = text
         }
+
+        override func becomeFirstResponder() -> Bool {
+            textField.becomeFirstResponder()
+        }
+
+        override func endEditing(_ force: Bool) -> Bool {
+            textField.endEditing(force)
+        }
     }
 }
 

--- a/p2p_wallet/Scenes/Main/SwapToken/Settings/Subviews/SwapTokenSettings.SlippageView.swift
+++ b/p2p_wallet/Scenes/Main/SwapToken/Settings/Subviews/SwapTokenSettings.SlippageView.swift
@@ -75,9 +75,16 @@ extension SwapTokenSettings {
 
         private func bind() {
             viewModel.customSlippageIsOpenedDriver
-                .map { !$0 }
-                .drive(customField.rx.isHidden)
+                .drive(onNext: { [weak self] in
+                    self?.customField.isHidden = !$0
+                    if $0 {
+                        self?.customField.becomeFirstResponder()
+                    } else {
+                        self?.customField.endEditing(true)
+                    }
+                })
                 .disposed(by: disposeBag)
+
             customField.rxText
                 .distinctUntilChanged()
                 .map { $0.flatMap(NumberFormatter().number) }


### PR DESCRIPTION
## Link jirra to issue
https://p2pvalidator.atlassian.net/browse/PWN-1591

## Description of the changes
- Auto show keyboard on custom slippage
