### PR TITLE
Ci/update pr info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,2 @@
-## Link jirra to issue
-https://p2pvalidator.atlassian.net/browse/PWN-
-
 ## Description of the changes
 - 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,5 +40,5 @@ jobs:
           title-template: '[${{ steps.find_issue.outputs.issue }}] '
           body-template: |
             ## Link jira to issue
-            ${{ secrets.JIRA_BASE_URL }}/${{ steps.find_issue.outputs.issue }}
+            ${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.find_issue.outputs.issue }}
           body-update-action: 'prefix'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   # Send task to review when pull request is opened
   return_task_to_in_progress:
-    name: Send task to review
+    name: Send task to review and update description
     runs-on: ubuntu-latest
 
     steps:
@@ -30,3 +30,15 @@ jobs:
         with:
           issue: ${{ steps.find_issue.outputs.issue }}
           transition: ${{ secrets.JIRA_REVIEW_TRANSITION_NAME }}
+
+      - name: Update PR description
+        if: ${{ steps.find_issue.outputs.issue }}
+        uses: tzkhan/pr-update-action@v2
+        with:
+          repo-token: "${{ secrets.SUBMODULES_ACCESS_TOKEN }}"
+          head-branch-regex: 'pwn-\d+'
+          title-template: '[${{ steps.find_issue.outputs.issue }}] '
+          body-template: |
+            ## Link jira to issue
+            ${{ secrets.JIRA_BASE_URL }}/${{ steps.find_issue.outputs.issue }}
+          body-update-action: 'prefix'


### PR DESCRIPTION
## Description of the changes
When a pr is created with the name that contains `pwn-`, the ci is updated for automatically adding pr info, so you don't need to specify number of task when creating pr again
- Add task number in title
- Add link on top off current description (keep current description unchanged)

## Example:  
From this:
<img width="906" alt="164156201-bd250b7c-0c55-4a95-9bc1-3d60c8f1a612" src="https://user-images.githubusercontent.com/6975538/164157234-0858ded0-8ad0-4a42-ae05-834201cd3454.png">

To this:
<img width="928" alt="Screen Shot 2022-04-20 at 12 24 45" src="https://user-images.githubusercontent.com/6975538/164156566-fbf1df1d-f317-487e-88bb-d5a752f53006.png">

