### PR TITLE
[PWN-3165] Reset password timer when exiting on the lock screen

### DIFF
--- a/p2p_wallet/Scenes/Main/Authentication/Authentication.PincodeViewController.swift
+++ b/p2p_wallet/Scenes/Main/Authentication/Authentication.PincodeViewController.swift
@@ -25,6 +25,7 @@ extension Authentication {
         private var biometryButton = BERef<UIButton>()
         private var pincodeView = BERef<WLPinCodeView>()
         private var logoView = BERef<UIImageView>()
+        private var lockingTimer: Timer?
 
         override var title: String? { didSet { navigationBar.view?.titleLabel.text = title } }
         var isIgnorable: Bool = false { didSet { navigationBar.view?.backIsHidden(!isIgnorable) } }
@@ -52,6 +53,10 @@ extension Authentication {
             self.viewModel = viewModel
             self.extraAction = extraAction
             super.init()
+        }
+
+        deinit {
+            invalidateTimer()
         }
 
         override func build() -> UIView {
@@ -185,7 +190,7 @@ extension Authentication {
             let lockingTimeInSeconds = lockingTimeInSeconds
 
             // Count down to next
-            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] timer in
+            lockingTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
                 // get current date
                 let now = Date()
 
@@ -206,9 +211,14 @@ extension Authentication {
                 if secondsPassed >= lockingTimeInSeconds {
                     self?.viewModel.setBlockedTime(nil)
                     self?.reset()
-                    timer.invalidate()
+                    self?.invalidateTimer()
                 }
             }
+        }
+
+        private func invalidateTimer() {
+            lockingTimer?.invalidate()
+            lockingTimer = nil
         }
     }
 }

--- a/p2p_wallet/Scenes/Main/Authentication/Authentication.ViewModel.swift
+++ b/p2p_wallet/Scenes/Main/Authentication/Authentication.ViewModel.swift
@@ -96,6 +96,7 @@ extension Authentication.ViewModel: AuthenticationViewModelType {
     }
 
     func signOut() {
+        setBlockedTime(nil)
         navigationSubject.accept(.signOutAlert { [weak self] in self?.logoutResponder.logout() })
     }
 }


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-3165

## Description of the changes
- invalidateTimer because timer works even if screen has already been closed
- reset blocking time from defaults when sign out
