### PR TITLE
Fix/app coordinator review

### DIFF
--- a/p2p_wallet/AppCoordinator/AppCoordinator.swift
+++ b/p2p_wallet/AppCoordinator/AppCoordinator.swift
@@ -12,7 +12,6 @@ import Resolver
 import SolanaSwift
 import UIKit
 
-@MainActor
 class AppCoordinator: Coordinator<Void> {
     // MARK: - Dependencies
 
@@ -110,15 +109,18 @@ class AppCoordinator: Coordinator<Void> {
         let vc = SplashViewController()
         window?.rootViewController = vc
         window?.makeKeyAndVisible()
-        vc.completionHandler = { [weak self] in
-            self?.warmup()
-        }
+        Task { await warmup() }
     }
 
-    func warmup() {
-        Task {
-            let account = await self.reloadData()
-            self.navigate(account: account)
+    private func warmup() async {
+        let account = await reloadData()
+
+        if let splashVC = window?.rootViewController as? SplashViewController {
+            splashVC.completionHandler = { [weak self] in
+                self?.navigate(account: account)
+            }
+        } else {
+            navigate(account: account)
         }
     }
 


### PR DESCRIPTION
## Description of the changes
- The @MainActor has been already been marked in `Coordinator`, so there is no need to mark `AppCoordinator` as `@MainActor` since it inherited from `Coordinator`.
- The completionHandler must be called AFTER the await reloadData() function, not BEFORE it.
