### PR TITLE
[PWN-4437] The apple authentication windows flashes after successfully passing biometrics

### DIFF
--- a/p2p_wallet/Services/Auth/SocialService/AppleSocialService.swift
+++ b/p2p_wallet/Services/Auth/SocialService/AppleSocialService.swift
@@ -25,9 +25,27 @@ final class AppleSocialService: NSObject, SocialService {
             let request = appleIDProvider.createRequest()
             let authorizationController = ASAuthorizationController(authorizationRequests: [request])
             authorizationController.delegate = self
+            authorizationController.presentationContextProvider = self
             request.requestedScopes = [.email]
             authorizationController.performRequests()
         }
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleSocialService: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for _: ASAuthorizationController) -> ASPresentationAnchor {
+        window() ?? UIWindow()
+    }
+
+    private func window() -> UIWindow? {
+        UIApplication.shared.connectedScenes.filter {
+            $0.activationState == .foregroundActive
+        }
+        .first(where: { $0 is UIWindowScene })
+        .flatMap { $0 as? UIWindowScene }?.windows
+        .first(where: \.isKeyWindow)
     }
 }
 


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-4437

## Description of the changes
- implementation of ASAuthorizationControllerPresentationContextProviding

I could not repeat the issue so it is a guess fix. I followed an official documentation for sign in, it might help