### PR TITLE
[PWN-5409] Migrate sync icloud keychain values to local one

### DIFF
--- a/p2p_wallet/Services/Storage/KeychainStorage.swift
+++ b/p2p_wallet/Services/Storage/KeychainStorage.swift
@@ -30,13 +30,6 @@ class KeychainStorage {
 
     // MARK: - Services
 
-    /// This keychain storage will sync across devices
-    // let icloudKeychain: KeychainSwift = {
-    //     let kc = KeychainSwift()
-    //     kc.synchronizable = true
-    //     return kc
-    // }()
-
     /// This keychain storage will only locally store in device
     let localKeychain: KeychainSwift = .init()
 
@@ -110,6 +103,11 @@ class KeychainStorage {
             }
             // mark as completed
             UserDefaults.standard.set(true, forKey: ubiquitousKeyValueStoreToKeychain)
+        }
+
+        [pincodeKey, phrasesKey, derivableTypeKey, walletIndexKey].forEach { key in
+            guard let data = icloudKeychain.getData(key), localKeychain.getData(key) == nil else { return }
+            localKeychain.set(data, forKey: key)
         }
     }
 


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-5409

## Description of the changes
- The problem is about KeychainSwift library. In old version there was synchronizable keychain. Now it is not. So the query does not contain kSecAttrSynchronizableAny attribute and keychain does not return any value.

"If the key is not supplied, or has a value of kCFBooleanFalse, then no synchronizable items will be added or returned. A predefined value, kSecAttrSynchronizableAny, may be provided instead of kCFBooleanTrue if both synchronizable and non-synchronizable results are desired." - documentation

Hot fix here but I suggest considering to remove this library in the future.