### PR TITLE
[PWN-6341] feat: disable build on no-qa task

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   upload_build_for_testing:
     name: Upload build for testing
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'auto:qa-deploy') }}
+    if: contains(github.event.pull_request.labels.*.name, 'auto:qa-deploy') && !contains(github.event.pull_request.labels.*.name, 'no-qa')
 
     runs-on: macos-12
 

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   upload_build_for_testing:
     name: Upload build for testing
-    if: contains(github.event.pull_request.labels.*.name, 'auto:qa-deploy') && !contains(github.event.pull_request.labels.*.name, 'no-qa')
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'auto:qa-deploy') && !contains(github.event.pull_request.labels.*.name, 'no-qa') }}
 
     runs-on: macos-12
 

--- a/.github/workflows/manual-feature-high-priority-test.yml
+++ b/.github/workflows/manual-feature-high-priority-test.yml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 jobs:
   upload_build_for_testing:
     name: Manually upload build for testing
-    if: !contains(github.event.pull_request.labels.*.name, 'no-qa')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-qa') }}
     runs-on: [self-hosted, macOS]
 
     steps:

--- a/.github/workflows/manual-feature-high-priority-test.yml
+++ b/.github/workflows/manual-feature-high-priority-test.yml
@@ -3,6 +3,7 @@ on: workflow_dispatch
 jobs:
   upload_build_for_testing:
     name: Manually upload build for testing
+    if: !contains(github.event.pull_request.labels.*.name, 'no-qa')
     runs-on: [self-hosted, macOS]
 
     steps:

--- a/.github/workflows/manual-feature-test.yml
+++ b/.github/workflows/manual-feature-test.yml
@@ -3,6 +3,7 @@ on: workflow_dispatch
 jobs:
   upload_build_for_testing:
     name: Manually upload build for testing
+    if: !contains(github.event.pull_request.labels.*.name, 'no-qa')
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/manual-feature-test.yml
+++ b/.github/workflows/manual-feature-test.yml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 jobs:
   upload_build_for_testing:
     name: Manually upload build for testing
-    if: !contains(github.event.pull_request.labels.*.name, 'no-qa')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-qa') }}
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -6,7 +6,7 @@ jobs:
   # Return task back to In Progress if pull request is changes requested
   return_task_to_in_progress:
     name: Return task back to In Progress if pull request is changes requested
-    if: github.event.review.state == 'changes_requested' && !contains(github.event.pull_request.labels.*.name, 'no-qa')
+    if: ${{ github.event.review.state == 'changes_requested' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +35,7 @@ jobs:
   # Upload build for testing when pull request is approved
   upload_build_for_testing:
     name: Upload build for testing when pull request is approved
-    if: github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'no-qa')
+    if: ${{ github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'no-qa') }}
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -35,7 +35,7 @@ jobs:
   # Upload build for testing when pull request is approved
   upload_build_for_testing:
     name: Upload build for testing when pull request is approved
-    if: github.event.review.state == 'approved' || github.event.label.name == 'auto-deploy-to-qa'
+    if: github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'no-qa')
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -6,7 +6,7 @@ jobs:
   # Return task back to In Progress if pull request is changes requested
   return_task_to_in_progress:
     name: Return task back to In Progress if pull request is changes requested
-    if: github.event.review.state == 'changes_requested'
+    if: github.event.review.state == 'changes_requested' && !contains(github.event.pull_request.labels.*.name, 'no-qa')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-6341

## Description of the changes
What is the problem?
- Some pull request that doesn’t require build but it builds anyway because of pr approvals
What is the suggested solution?
- Mark PR as `no-qa` and after approval there would be no build created
What is “neсessary”, and what is “nice to have”?
- Add excepting condition `no-qa` on github-actions
Definition of done (criteria to consider task done)
- PR with tag `no-qa` will not create a new build
