### PR TITLE
[PWN-6475] iOS: Боттом шит деталей транзакции закрывается дергано при тапе по пустому месту

### DIFF
--- a/p2p_wallet/Extensions/UIHostingController+Extensions.swift
+++ b/p2p_wallet/Extensions/UIHostingController+Extensions.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+
+extension UIHostingController {
+    /// Convenience init for overriding default avoiding-keyboard behavior in UIHostingController
+    convenience public init(rootView: Content, ignoresKeyboard: Bool) {
+        self.init(rootView: rootView)
+
+        if ignoresKeyboard {
+            // get the class
+            guard let viewClass = object_getClass(view) else { return }
+
+            // replace view's class by _IgnoresKeyboard alternative class
+            let viewSubclassName = String(cString: class_getName(viewClass)).appending("_IgnoresKeyboard")
+            
+            // if _IgnoresKeyboard class is available
+            if let viewSubclass = NSClassFromString(viewSubclassName) {
+                object_setClass(view, viewSubclass)
+            }
+            
+            // _IgnoresKeyboard is not available, observe the keyboard event and disable re-layout behavior
+            else {
+                guard let viewClassNameUtf8 = (viewSubclassName as NSString).utf8String else { return }
+                guard let viewSubclass = objc_allocateClassPair(viewClass, viewClassNameUtf8, 0) else { return }
+
+                if let method = class_getInstanceMethod(viewClass, NSSelectorFromString("keyboardWillShowWithNotification:")) {
+                    let keyboardWillShow: @convention(block) (AnyObject, AnyObject) -> Void = { _, _ in }
+                    class_addMethod(viewSubclass, NSSelectorFromString("keyboardWillShowWithNotification:"),
+                                    imp_implementationWithBlock(keyboardWillShow), method_getTypeEncoding(method))
+                }
+                objc_registerClassPair(viewSubclass)
+                object_setClass(view, viewSubclass)
+            }
+        }
+    }
+}

--- a/p2p_wallet/Scenes/Main/Send/Input/Details/FeePrompt/SendInputFeePromptCoordinator.swift
+++ b/p2p_wallet/Scenes/Main/Send/Input/Details/FeePrompt/SendInputFeePromptCoordinator.swift
@@ -25,8 +25,8 @@ final class SendInputFeePromptCoordinator: Coordinator<Wallet?> {
         parentController.present(controller, animated: true)
 
         viewModel.close
-            .sink(receiveValue: { [weak self] in
-                controller.dismiss(animated: true)
+            .sink(receiveValue: { [weak self, weak controller] in
+                controller?.dismiss(animated: true)
                 self?.subject.send(completion: .finished)
             })
             .store(in: &subscriptions)

--- a/p2p_wallet/Scenes/Main/Send/Input/Details/FreeTransactionsDetail/SendInputFreeTransactionsDetailCoordinator.swift
+++ b/p2p_wallet/Scenes/Main/Send/Input/Details/FreeTransactionsDetail/SendInputFreeTransactionsDetailCoordinator.swift
@@ -20,7 +20,7 @@ final class SendInputFreeTransactionsDetailCoordinator: Coordinator<Void> {
 
         transition = PanelTransition()
         transition?.containerHeight = 484.adaptiveHeight
-        let feeController = UIHostingController(rootView: view)
+        let feeController = UIHostingController(rootView: view, ignoresKeyboard: true)
         feeController.view.layer.cornerRadius = 20
         feeController.view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         feeController.transitioningDelegate = transition

--- a/p2p_wallet/Scenes/Main/Send/Input/Details/SendTransactionDetails/SendTokenDetailsCoordinator.swift
+++ b/p2p_wallet/Scenes/Main/Send/Input/Details/SendTransactionDetails/SendTokenDetailsCoordinator.swift
@@ -40,7 +40,7 @@ final class SendTransactionDetailsCoordinator: Coordinator<SendTransactionDetail
 
         transition = PanelTransition()
         transition?.containerHeight = view.viewHeight
-        let viewController = UIHostingController(rootView: view)
+        let viewController = UIHostingController(rootView: view, ignoresKeyboard: true)
         viewController.view.layer.cornerRadius = 20
         viewController.transitioningDelegate = transition
         viewController.modalPresentationStyle = .custom

--- a/p2p_wallet/Scenes/Main/Send/Input/SendInputCoordinator.swift
+++ b/p2p_wallet/Scenes/Main/Send/Input/SendInputCoordinator.swift
@@ -110,9 +110,9 @@ final class SendInputCoordinator: Coordinator<SendResult> {
             feeInSOL: viewModel.currentState.fee,
             availableFeeTokens: feeWallets
         ))
-        .sink(receiveValue: { feeToken in
+        .sink(receiveValue: { [weak viewModel] feeToken in
             guard let feeToken = feeToken else { return }
-            viewModel.changeFeeToken.send(feeToken)
+            viewModel?.changeFeeToken.send(feeToken)
         })
         .store(in: &subscriptions)
     }
@@ -122,10 +122,10 @@ final class SendInputCoordinator: Coordinator<SendResult> {
             parentController: vc,
             sendInputViewModel: viewModel
         ))
-        .sink { result in
+        .sink { [weak self] result in
             switch result {
             case let .redirectToFeePrompt(tokens):
-                self.openFeePropmt(from: vc, viewModel: viewModel, feeWallets: tokens)
+                self?.openFeePropmt(from: vc, viewModel: viewModel, feeWallets: tokens)
             }
         }
         .store(in: &subscriptions)


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-6475

## Description of the changes
- Before
https://user-images.githubusercontent.com/6975538/209905460-aabc67f2-ac74-44e0-b3ce-606b603733f1.mov
- After
https://user-images.githubusercontent.com/6975538/209905472-b3c94961-cdc4-40b4-8b03-ca3f734748ac.mov
