### PR TITLE
[PWN-6960] Feature/pwn 6960 cancel previous action

### DIFF
--- a/p2p_wallet/Scenes/Main/Swap/State/JupiterSwapStateMachine.swift
+++ b/p2p_wallet/Scenes/Main/Swap/State/JupiterSwapStateMachine.swift
@@ -1,21 +1,66 @@
-import Send // TODO: I will extract StateMachine in core module inside Key App Kit
 import Combine
 
+public protocol StateMachine {
+    var services: Services { get }
+    func accept(action: Action, cancelPreviousAction: Bool) async -> State
+}
+
+
 actor JupiterSwapStateMachine: StateMachine {
+    // MARK: - Properties
+
     private nonisolated let stateSubject: CurrentValueSubject<JupiterSwapState, Never>
+    
+    private var currentTask: Task<JupiterSwapState, Never>?
+    private var currentAction: JupiterSwapAction?
+
+    // MARK: - Public properties
 
     nonisolated var statePublisher: AnyPublisher<JupiterSwapState, Never> { stateSubject.eraseToAnyPublisher() }
     nonisolated var currentState: JupiterSwapState { stateSubject.value }
 
     nonisolated let services: JupiterSwapServices
 
+    // MARK: - Initializer
+
     init(initialState: JupiterSwapState, services: JupiterSwapServices) {
         stateSubject = .init(initialState)
         self.services = services
     }
+    
+    // MARK: - Accept function
 
+    nonisolated func accept(
+        action newAction: JupiterSwapAction,
+        cancelPreviousAction: Bool = true
+    ) async -> JupiterSwapState {
+        // cancel current action if needed
+        if cancelPreviousAction {
+            await currentTask?.cancel()
+        }
+        
+        // dispatch new action (can be immediately or after current action)
+        return await task(action: newAction)
+    }
+    
+    // MARK: - Dispatching
+    
+    private func task(action: JupiterSwapAction) async -> JupiterSwapState {
+        // save current action
+        saveCurrentAction(action)
+        
+        // assign task
+        currentTask = Task { await dispatch(action: action) }
+        
+        // append task to current stack
+        return await currentTask!.value
+    }
+    
     @discardableResult
-    func accept(action: JupiterSwapAction) async -> JupiterSwapState {
+    private func dispatch(action: JupiterSwapAction) async -> JupiterSwapState {
+        // save the last state
+        let lastState = currentState
+        
         // assert if action should be performed
         // for example if data is not changed, perform action is not needed
         guard JupiterSwapBusinessLogic.shouldPerformAction(
@@ -29,10 +74,12 @@ actor JupiterSwapStateMachine: StateMachine {
         if let progressState = JupiterSwapBusinessLogic.jupiterSwapProgressState(
             state: currentState, action: action
         ) {
+            guard Task.isNotCancelled else { return lastState }
             stateSubject.send(progressState)
         }
         
         // perform the action
+        guard Task.isNotCancelled else { return lastState }
         var newState = await JupiterSwapBusinessLogic.jupiterSwapBusinessLogic(
             state: currentState,
             action: action,
@@ -40,16 +87,25 @@ actor JupiterSwapStateMachine: StateMachine {
         )
 
         // return the state
+        guard Task.isNotCancelled else { return lastState }
         stateSubject.send(newState)
         
         // FIXME: - Create transaction if needed
+        guard Task.isNotCancelled else { return lastState }
         newState = await JupiterSwapBusinessLogic.createTransaction(
             state: newState,
             services: services
         )
         
+        guard Task.isNotCancelled else { return lastState }
         stateSubject.send(newState)
         
         return newState
+    }
+    
+    // MARK: - Helpers
+
+    private func saveCurrentAction(_ action: JupiterSwapAction) {
+        currentAction = action
     }
 }

--- a/p2p_wallet/Scenes/Main/Swap/Swap/JupiterSwapCoordinator.swift
+++ b/p2p_wallet/Scenes/Main/Swap/Swap/JupiterSwapCoordinator.swift
@@ -204,7 +204,10 @@ final class JupiterSwapCoordinator: Coordinator<Void> {
                 switch result {
                 case let .selectedSlippageBps(slippageBps):
                     Task { [weak viewModel] in
-                        await viewModel?.stateMachine.accept(action: .changeSlippageBps(slippageBps))
+                        await viewModel?.stateMachine.accept(
+                            action: .changeSlippageBps(slippageBps),
+                            waitForPreviousActionToComplete: false
+                        )
                     }
                 case let .selectedRoute(routeInfo):
                     guard let route = viewModel?.currentState.routes.first(where: {$0.id == routeInfo.id}),
@@ -213,7 +216,10 @@ final class JupiterSwapCoordinator: Coordinator<Void> {
                         return
                     }
                     Task { [weak viewModel] in
-                        await viewModel?.stateMachine.accept(action: .chooseRoute(route))
+                        await viewModel?.stateMachine.accept(
+                            action: .chooseRoute(route),
+                            waitForPreviousActionToComplete: false
+                        )
                     }
                 }
             })

--- a/p2p_wallet/Scenes/Main/Swap/Swap/Subviews/Input/SwapInputViewModel.swift
+++ b/p2p_wallet/Scenes/Main/Swap/Swap/Subviews/Input/SwapInputViewModel.swift
@@ -72,7 +72,10 @@ final class SwapInputViewModel: BaseViewModel, ObservableObject {
                 self.logChange(amount: value)
                 self.isAmountLoading = true && !self.isFromToken
                 if self.isFromToken {
-                    await self.stateMachine.accept(action: .changeAmountFrom(value ?? 0))
+                    await self.stateMachine.accept(
+                        action: .changeAmountFrom(value ?? 0),
+                        waitForPreviousActionToComplete: false
+                    )
                 }
                 self.isAmountLoading = false && !self.isFromToken
             }


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-6960

## Description of the changes
- Add Cache to manage `currentTask` (for canceling later). Cache type is `Actor` to make writing/reading `currentTask` safe from other asynchronous context.
- Mark function `accept(action:)` nonisolated, so the function can be called many times to avoid bottleneck.
- Add function `dispatch` that is isolated. It means that it will execute exactly 1 in a time.
- Add option `waitForPreviousActionToComplete` to manage the accepting of new task (action)