### PR TITLE
[PWN-8000] Misspell fix + added max digits

### DIFF
--- a/Packages/KeyAppKit/Sources/KeyAppKitCore/Blockchain/CryptoFormatter.swift
+++ b/Packages/KeyAppKit/Sources/KeyAppKitCore/Blockchain/CryptoFormatter.swift
@@ -109,6 +109,6 @@ public final class ETHCryptoFormatter: CryptoFormatter {
     }
 
     public override func string(for obj: Any?) -> String? {
-        super.string(for: obj, maxDigits: style == .short ? 8 : 18)
+        super.string(for: obj, maxDigits: style == .short ? 8 : nil)
     }
 }

--- a/Packages/KeyAppKit/Sources/KeyAppKitCore/Blockchain/CryptoFormatter.swift
+++ b/Packages/KeyAppKit/Sources/KeyAppKitCore/Blockchain/CryptoFormatter.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//
-//
-//  Created by Giang Long Tran on 11.03.2023.
-//
-
 import BigInt
 import Foundation
 
@@ -13,7 +6,23 @@ public protocol CryptoAmountConvertible {
     var asCryptoAmount: CryptoAmount { get }
 }
 
-/// A string-formatter for crypto.
+public enum CryptoFormatterStyle {
+    /// Short representation of crypto numbers, e.g. limited fraction digits
+    case short
+    case long
+}
+
+public class CryptoFormatterFactory {
+    public static func formatter(with token: SomeToken, style: CryptoFormatterStyle = .long) -> CryptoFormatter {
+        if token.tokenPrimaryKey == "native-ethereum" && token.decimals == 18 {
+            return ETHCryptoFormatter(style: style)
+        } else {
+            return CryptoFormatter()
+        }
+    }
+}
+
+/// A general string-formatter for crypto
 public class CryptoFormatter: Formatter {
     public let defaultValue: String
     public let prefix: String
@@ -87,5 +96,19 @@ public class CryptoFormatter: Formatter {
         } else {
             return "\(formattedAmount) \(amount.token.symbol)"
         }
+    }
+}
+
+/// Crypto formatter for ETH-like tokens
+public final class ETHCryptoFormatter: CryptoFormatter {
+    let style: CryptoFormatterStyle
+
+    init(style: CryptoFormatterStyle) {
+        self.style = style
+        super.init()
+    }
+
+    public override func string(for obj: Any?) -> String? {
+        super.string(for: obj, maxDigits: style == .short ? 8 : 18)
     }
 }

--- a/Packages/KeyAppKit/Sources/KeyAppKitCore/Blockchain/CryptoFormatter.swift
+++ b/Packages/KeyAppKit/Sources/KeyAppKitCore/Blockchain/CryptoFormatter.swift
@@ -43,9 +43,13 @@ public class CryptoFormatter: Formatter {
         formattedValue(for: obj)
     }
 
+    public func string(for obj: Any?, maxDigits: Int? = nil) -> String? {
+        formattedValue(for: obj, maxDigits: maxDigits)
+    }
+
     // MARK: - Private
 
-    private func formattedValue(for obj: Any?) -> String? {
+    private func formattedValue(for obj: Any?, maxDigits: Int? = nil) -> String? {
         let amount: CryptoAmount?
 
         if let obj = obj as? CryptoAmount {
@@ -63,7 +67,11 @@ public class CryptoFormatter: Formatter {
         formatter.numberStyle = .decimal
         formatter.decimalSeparator = "."
         formatter.groupingSeparator = " "
-        formatter.maximumFractionDigits = Int(amount.token.decimals)
+        if let maxDigits {
+            formatter.maximumFractionDigits = maxDigits
+        } else {
+            formatter.maximumFractionDigits = Int(amount.token.decimals)
+        }
 
         let convertedValue = Decimal(string: String(amount.amount))
         guard var formattedAmount = formatter.string(for: convertedValue) else {

--- a/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/HomeAccountsViewModel+Helper.swift
+++ b/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/HomeAccountsViewModel+Helper.swift
@@ -43,11 +43,11 @@ extension HomeAccountsViewModel {
         }
     }
 
-    static func shouldInVisiableSection(ethereumAcount: RendableEthereumAccount) -> Bool {
+    static func shouldInVisiableSection(ethereumAcount: RenderableEthereumAccount) -> Bool {
         (ethereumAcount.account.balanceInFiat?.value ?? 0) >= 1
     }
 
-    static func shouldInIgnoreSection(ethereumAcount: RendableEthereumAccount) -> Bool {
+    static func shouldInIgnoreSection(ethereumAcount: RenderableEthereumAccount) -> Bool {
         (ethereumAcount.account.balanceInFiat?.value ?? 0) > 0
     }
 

--- a/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/HomeAccountsViewModel.swift
+++ b/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/HomeAccountsViewModel.swift
@@ -38,7 +38,7 @@ final class HomeAccountsViewModel: BaseViewModel, ObservableObject {
 
     /// Solana accounts.
     @Published private(set) var solanaAccountsState: AsyncValueState<[RendableSolanaAccount]> = .init(value: [])
-    @Published private(set) var ethereumAccountsState: AsyncValueState<[RendableEthereumAccount]> = .init(value: [])
+    @Published private(set) var ethereumAccountsState: AsyncValueState<[RenderableEthereumAccount]> = .init(value: [])
 
     /// Primary list accounts.
     var accounts: [any RendableAccount] {
@@ -155,7 +155,7 @@ final class HomeAccountsViewModel: BaseViewModel, ObservableObject {
 
                     let isClaimable = !account.isClaiming && balanceInFiat >= CurrencyAmount(usd: 1)
 
-                    return RendableEthereumAccount(
+                    return RenderableEthereumAccount(
                         account: account.account,
                         isClaiming: isClaiming,
                         onTap: nil,

--- a/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/Model/RendableAccount+EthereumAccount.swift
+++ b/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/Model/RendableAccount+EthereumAccount.swift
@@ -31,7 +31,8 @@ struct RenderableEthereumAccount: RendableAccount {
     }
 
     var subtitle: String {
-        CryptoFormatter().string(for: account.representedBalance, maxDigits: account.token.contractType == .native ? 8 : nil)
+        CryptoFormatterFactory.formatter(with: account.representedBalance.token)
+            .string(for: account.representedBalance)
             ?? "0 \(account.token.symbol)"
     }
 

--- a/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/Model/RendableAccount+EthereumAccount.swift
+++ b/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/Model/RendableAccount+EthereumAccount.swift
@@ -31,7 +31,7 @@ struct RenderableEthereumAccount: RendableAccount {
     }
 
     var subtitle: String {
-        CryptoFormatterFactory.formatter(with: account.representedBalance.token)
+        CryptoFormatterFactory.formatter(with: account.representedBalance.token, style: .short)
             .string(for: account.representedBalance)
             ?? "0 \(account.token.symbol)"
     }

--- a/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/Model/RendableAccount+EthereumAccount.swift
+++ b/p2p_wallet/Scenes/Main/NewHome/Subview/AccountList/Model/RendableAccount+EthereumAccount.swift
@@ -1,15 +1,8 @@
-//
-//  RendableAccount+EthereumAccount.swift
-//  p2p_wallet
-//
-//  Created by Giang Long Tran on 11.03.2023.
-//
-
 import Foundation
 import KeyAppBusiness
 import KeyAppKitCore
 
-struct RendableEthereumAccount: RendableAccount {
+struct RenderableEthereumAccount: RendableAccount {
     let account: EthereumAccount
 
     var id: String {
@@ -38,13 +31,11 @@ struct RendableEthereumAccount: RendableAccount {
     }
 
     var subtitle: String {
-        CryptoFormatter().string(for: account.representedBalance)
+        CryptoFormatter().string(for: account.representedBalance, maxDigits: account.token.contractType == .native ? 8 : nil)
             ?? "0 \(account.token.symbol)"
     }
 
     var detail: AccountDetail {
-        
-        
         if let onClaim {
             return .button(label: L10n.claim, action: onClaim)
         } else if isClaiming {

--- a/p2p_wallet/Scenes/Main/Wormhole/Claim/WormholeClaimModel.swift
+++ b/p2p_wallet/Scenes/Main/Wormhole/Claim/WormholeClaimModel.swift
@@ -51,7 +51,8 @@ struct WormholeClaimEthereumModel: WormholeClaimModel {
     }
 
     var title: String {
-        CryptoFormatter().string(for: account.representedBalance, maxDigits: account.token.contractType == .native ? 8 : nil)
+        CryptoFormatterFactory.formatter(with: account.representedBalance.token)
+            .string(for: account.representedBalance)
             ?? "0 \(account.token.symbol)"
     }
 

--- a/p2p_wallet/Scenes/Main/Wormhole/Claim/WormholeClaimModel.swift
+++ b/p2p_wallet/Scenes/Main/Wormhole/Claim/WormholeClaimModel.swift
@@ -51,7 +51,7 @@ struct WormholeClaimEthereumModel: WormholeClaimModel {
     }
 
     var title: String {
-        CryptoFormatter().string(for: account.representedBalance)
+        CryptoFormatter().string(for: account.representedBalance, maxDigits: account.token.contractType == .native ? 8 : nil)
             ?? "0 \(account.token.symbol)"
     }
 

--- a/p2p_wallet/Scenes/Main/Wormhole/Claim/WormholeClaimModel.swift
+++ b/p2p_wallet/Scenes/Main/Wormhole/Claim/WormholeClaimModel.swift
@@ -51,7 +51,7 @@ struct WormholeClaimEthereumModel: WormholeClaimModel {
     }
 
     var title: String {
-        CryptoFormatterFactory.formatter(with: account.representedBalance.token)
+        CryptoFormatterFactory.formatter(with: account.representedBalance.token, style: .short)
             .string(for: account.representedBalance)
             ?? "0 \(account.token.symbol)"
     }


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-8000

## Description of the changes

- Added maxDigits in formatter, so you can specify how many fraction digits are possible
- Fixed misspeling in word "Render". Renames Rendable to Renderable for a RenderableEthereumAccount struct



