### PR TITLE
[PWN-8185] If price is not retrieved, do not display fiat amount on c…

### DIFF
--- a/p2p_wallet/Scenes/Main/History/New/Model/RendableListTransactionItem+Mock.swift
+++ b/p2p_wallet/Scenes/Main/History/New/Model/RendableListTransactionItem+Mock.swift
@@ -77,7 +77,7 @@ extension MockedRendableListTransactionItem {
             icon: .single(URL(string: Token.renBTC.logoURI!)!),
             title: "Receive",
             subtitle: "From ...S39N",
-            detail: (.positive, "+$5 268.65"),
+            detail: (.unchanged, ""),
             subdetail: "+0.3271523 renBTC"
         )
     }

--- a/p2p_wallet/Scenes/Main/History/New/Subview/HistoryItemView.swift
+++ b/p2p_wallet/Scenes/Main/History/New/Subview/HistoryItemView.swift
@@ -38,22 +38,13 @@ struct HistoryItemView: View {
         } label: {
             HStack {
                 HistoryIconView(icon: item.icon)
-                VStack(spacing: 4) {
-                    HStack(spacing: 5) {
-                        Text(item.title)
-                            .foregroundColor(Color(Asset.Colors.night.color))
-                            .fontWeight(.semibold)
-                            .apply(style: .text2)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                        Text(item.detail.1)
-                            .fontWeight(.semibold)
-                            .apply(style: .text2)
-                            .foregroundColor(detailColor)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.trailing)
-                    }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .foregroundColor(Color(Asset.Colors.night.color))
+                        .fontWeight(.semibold)
+                        .apply(style: .text2)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
 
                     HStack(spacing: 4) {
                         switch item.status {
@@ -75,11 +66,24 @@ struct HistoryItemView: View {
                         Text(item.subtitle)
                             .foregroundColor(Color(Asset.Colors.mountain.color))
                             .apply(style: .label1)
-                        Spacer()
-                        Text(item.subdetail)
-                            .foregroundColor(Color(Asset.Colors.mountain.color))
-                            .apply(style: .label1)
                     }
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 4) {
+                    if !item.detail.1.isEmpty {
+                        Text(item.detail.1)
+                            .fontWeight(.semibold)
+                            .apply(style: .text2)
+                            .foregroundColor(detailColor)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    Text(item.subdetail)
+                        .foregroundColor(Color(Asset.Colors.mountain.color))
+                        .apply(style: .label1)
                 }
             }
             .padding(.horizontal, 16)

--- a/p2p_wallet/Scenes/Main/ReceiveFundsViaLink/ClaimSentViaLinkTransaction.swift
+++ b/p2p_wallet/Scenes/Main/ReceiveFundsViaLink/ClaimSentViaLinkTransaction.swift
@@ -31,7 +31,8 @@ struct ClaimSentViaLinkTransaction: RawTransactionType {
     }
     
     var amountInFiat: Double? {
-        Resolver.resolve(PricesServiceType.self).currentPrice(mint: token.address)?.value * tokenAmount
+        guard let value = Resolver.resolve(PricesServiceType.self).currentPrice(mint: token.address)?.value else { return nil }
+        return value * tokenAmount
     }
     
     func createRequest() async throws -> String {

--- a/p2p_wallet/Scenes/Main/TransactionDetailView/Model/RendableDetailTransaction+PendingTransaction.swift
+++ b/p2p_wallet/Scenes/Main/TransactionDetailView/Model/RendableDetailTransaction+PendingTransaction.swift
@@ -145,7 +145,10 @@ struct RendableDetailPendingTransaction: RendableTransactionDetail {
                 return .unchanged("")
             }
         case let transaction as ClaimSentViaLinkTransaction:
-            return .positive("+\(transaction.amountInFiat?.fiatAmountFormattedString() ?? "")")
+            if let amountInFiat = transaction.amountInFiat?.fiatAmountFormattedString() {
+                return .positive("+\(amountInFiat)")
+            }
+            return .unchanged("")
 
 //        case let transaction as WormholeClaimTransaction:
 //            if let value = CurrencyFormatter().string(for: transaction.bundle.resultAmount) {


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-8185

…laim history screen

## Description of the changes
- I change [HistoryItemView.swift](https://github.com/p2p-org/p2p-wallet-ios/compare/bugfix/PWN-8185?expand=1#diff-8abf8bb5ebb7076168cd8d17a3b9c297b61f34253b8044719511ecc52a1f5e72) from HStack of title and detail to VStack of title and status to show correctly empty fiat amount. Please look in the [task](https://p2pvalidator.atlassian.net/browse/PWN-8185) and the screen ("Receive item") I provided. 
<img width="456" alt="Screenshot 2023-04-26 at 18 28 28" src="https://user-images.githubusercontent.com/11137094/234625217-42c1a81f-8b81-4bfc-a7fe-6856a9219174.png">
