### PR TITLE
[PWN-8332] Do not call update user wallets every time view is appeare…

### DIFF
--- a/p2p_wallet/Scenes/Main/Common/ChooseItem/ChooseItemViewModel.swift
+++ b/p2p_wallet/Scenes/Main/Common/ChooseItem/ChooseItemViewModel.swift
@@ -37,11 +37,6 @@ private extension ChooseItemViewModel {
                 guard let self else { return }
                 switch state.status {
                 case .ready:
-                    if self.isLoading {
-                        // Show skeleton only once, after that only seamless updates
-                        self.isLoading = false
-                    }
-
                     _ = state.apply { data in
                         let dataWithoutChosen = data.map { section in
                             ChooseItemListSection(
@@ -53,6 +48,11 @@ private extension ChooseItemViewModel {
                         if !self.isSearchGoing {
                             self.sections = self.allItems
                         }
+                    }
+
+                    if self.isLoading {
+                        // Show skeleton only once, after that only seamless updates
+                        self.isLoading = false
                     }
 
                 default:

--- a/p2p_wallet/Scenes/Main/Swap/Swap/SwapView.swift
+++ b/p2p_wallet/Scenes/Main/Swap/Swap/SwapView.swift
@@ -41,10 +41,10 @@ struct SwapView: View {
             }
         }
         .onAppear {
-            viewModel.isViewAppeared.send(true)
+            viewModel.isViewAppeared = true
         }
         .onDisappear {
-            viewModel.isViewAppeared.send(false)
+            viewModel.isViewAppeared = false
         }
     }
 }


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-8332

…d. Hide loading state only after data is fully appeared

## Description of the changes
- So 'Publishers.CombineLatest(
            walletsRepository.dataPublisher.removeDuplicates(),
            isViewAppeared.eraseToAnyPublisher().removeDuplicates()
        )" was called every time when screen is appeared. It messed around and delayed token choice, so there might be a problem with that.
- Also loading state should be hidden after data is fully presented (small fix)

These guesses might optimise the view responsiveness
