### PR TITLE
feat: unify error type

### DIFF
--- a/Packages/KeyAppKit/Sources/BankTransfer/Models/BankTransferError.swift
+++ b/Packages/KeyAppKit/Sources/BankTransfer/Models/BankTransferError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BankTransferServiceError: Error {
+enum BankTransferError: Error {
     case invalidKeyPair
     case missingUserId
 }

--- a/Packages/KeyAppKit/Sources/BankTransfer/Service/BankTransferServiceImpl.swift
+++ b/Packages/KeyAppKit/Sources/BankTransfer/Service/BankTransferServiceImpl.swift
@@ -90,7 +90,7 @@ extension BankTransferServiceImpl: BankTransferService {
     }
     
     public func getKYCToken() async throws -> String {
-        guard let userId = subject.value.value.userId else { throw BankTransferServiceError.missingUserId }
+        guard let userId = subject.value.value.userId else { throw BankTransferError.missingUserId }
         return try await repository.getKYCToken(userId: userId)
     }
     

--- a/Packages/KeyAppKit/Sources/BankTransfer/Striga/Models/StrigaEndpoint.swift
+++ b/Packages/KeyAppKit/Sources/BankTransfer/Striga/Models/StrigaEndpoint.swift
@@ -130,7 +130,7 @@ extension KeyPair {
                 secretKey: secretKey
             ).base64EncodedString()
         else {
-            throw BankTransferServiceError.invalidKeyPair
+            throw BankTransferError.invalidKeyPair
         }
         // return unixtime:signature_of_unixtime_by_user_privatekey_in_base64_format
         return [timestamp, signedTimestampMessage].joined(separator: ":")

--- a/Packages/KeyAppKit/Sources/BankTransfer/Striga/Repository/DataProviders/StrigaRemoteProviderImpl.swift
+++ b/Packages/KeyAppKit/Sources/BankTransfer/Striga/Repository/DataProviders/StrigaRemoteProviderImpl.swift
@@ -32,10 +32,6 @@ public final class StrigaRemoteProviderImpl {
 
 // MARK: - StrigaProvider
 
-public enum StrigaRemoteProviderError: Error {
-    case noUserId
-}
-
 extension StrigaRemoteProviderImpl: StrigaRemoteProvider {
 
     public func getUserId() async throws -> String? {
@@ -43,14 +39,14 @@ extension StrigaRemoteProviderImpl: StrigaRemoteProvider {
     }
     
     public func getKYCStatus() async throws -> StrigaKYC.Status {
-        guard let userId = try await getUserId() else { throw StrigaRemoteProviderError.noUserId }
+        guard let userId = try await getUserId() else { throw BankTransferError.missingUserId }
         return try await getUserDetails(userId: userId).KYC.status
     }
     
     public func getUserDetails(
         userId: String
     ) async throws -> StrigaUserDetailsResponse {
-        guard let keyPair else { throw BankTransferServiceError.invalidKeyPair }
+        guard let keyPair else { throw BankTransferError.invalidKeyPair }
         let endpoint = try StrigaEndpoint.getUserDetails(baseURL: baseURL, keyPair: keyPair, userId: userId)
         return try await httpClient.request(endpoint: endpoint, responseModel: StrigaUserDetailsResponse.self)
     }
@@ -58,7 +54,7 @@ extension StrigaRemoteProviderImpl: StrigaRemoteProvider {
     public func createUser(
         model: StrigaCreateUserRequest
     ) async throws -> StrigaCreateUserResponse {
-        guard let keyPair else { throw BankTransferServiceError.invalidKeyPair }
+        guard let keyPair else { throw BankTransferError.invalidKeyPair }
         let endpoint = try StrigaEndpoint.createUser(baseURL: baseURL, keyPair: keyPair, body: model)
         return try await httpClient.request(endpoint: endpoint, responseModel: StrigaCreateUserResponse.self)
     }
@@ -67,7 +63,7 @@ extension StrigaRemoteProviderImpl: StrigaRemoteProvider {
         userId: String,
         verificationCode: String
     ) async throws {
-        guard let keyPair else { throw BankTransferServiceError.invalidKeyPair }
+        guard let keyPair else { throw BankTransferError.invalidKeyPair }
         let endpoint = try StrigaEndpoint.verifyMobileNumber(
             baseURL: baseURL,
             keyPair: keyPair,
@@ -78,13 +74,13 @@ extension StrigaRemoteProviderImpl: StrigaRemoteProvider {
     }
     
     public func resendSMS(userId: String) async throws {
-        guard let keyPair else { throw BankTransferServiceError.invalidKeyPair }
+        guard let keyPair else { throw BankTransferError.invalidKeyPair }
         let endpoint = try StrigaEndpoint.resendSMS(baseURL: baseURL, keyPair: keyPair, userId: userId)
         _ = try await httpClient.request(endpoint: endpoint, responseModel: String.self)
     }
     
     public func getKYCToken(userId: String) async throws -> String {
-        guard let keyPair else { throw BankTransferServiceError.invalidKeyPair }
+        guard let keyPair else { throw BankTransferError.invalidKeyPair }
         let endpoint = try StrigaEndpoint.getKYCToken(baseURL: baseURL, keyPair: keyPair, userId: userId)
         
         return try await httpClient.request(endpoint: endpoint, responseModel: StrigaUserGetTokenResponse.self)


### PR DESCRIPTION
## Description of the changes
- We unify the error type, instead of having 2 types of error: `BankTransferServiceError` + `StrigaProviderError`, which have the same `missingUserId` error, we unify it into `BankTransferError`