### PR TITLE
feat: createUser

### DIFF
--- a/Packages/KeyAppKit/Sources/BankTransfer/Service/BankTransferService.swift
+++ b/Packages/KeyAppKit/Sources/BankTransfer/Service/BankTransferService.swift
@@ -4,7 +4,6 @@ import KeyAppKitCore
 public protocol BankTransferService {
     var state: AnyPublisher<AsyncValueState<UserData>, Never> { get }
 
-    func save(userData: UserData) async throws
     func reload() async
 
     func isBankTransferAvailable() -> Bool
@@ -17,7 +16,7 @@ public protocol BankTransferService {
     // MARK: - Remote actions
 
     func getRegistrationData() async throws -> BankTransferRegistrationData
-    func createUser(data: BankTransferRegistrationData) async throws -> UserData
+    func createUser(data: BankTransferRegistrationData) async throws
     func updateUser(data: BankTransferRegistrationData) async throws
 
     func getOTP() async throws

--- a/Packages/KeyAppKit/Sources/BankTransfer/Service/BankTransferServiceImpl.swift
+++ b/Packages/KeyAppKit/Sources/BankTransfer/Service/BankTransferServiceImpl.swift
@@ -26,10 +26,6 @@ extension BankTransferServiceImpl: BankTransferService {
         subject.eraseToAnyPublisher()
     }
     
-    public func save(userData: UserData) async throws {
-        fatalError("Not implemented")
-    }
-    
     public func reload() async {
         // mark as loading
         subject.send(
@@ -67,9 +63,16 @@ extension BankTransferServiceImpl: BankTransferService {
         try await repository.updateUserLocally(registrationData: data)
     }
     
-    public func createUser(data: BankTransferRegistrationData) async throws -> UserData {
+    public func createUser(data: BankTransferRegistrationData) async throws {
         let response = try await repository.createUser(registrationData: data)
-        return UserData(userId: response.userId, mobileVerified: false, kycVerified: response.KYC.verified)
+        let userData = UserData(userId: response.userId, mobileVerified: false, kycVerified: response.KYC.verified)
+        subject.send(
+            .init(
+                status: subject.value.status,
+                value: userData,
+                error: subject.value.error
+            )
+        )
     }
     
     public func updateUser(data: BankTransferRegistrationData) async throws {

--- a/p2p_wallet/Scenes/Main/BankTransfer/StrigaRegistration/SecondStep/StrigaRegistrationSecondStepViewModel.swift
+++ b/p2p_wallet/Scenes/Main/BankTransfer/StrigaRegistration/SecondStep/StrigaRegistrationSecondStepViewModel.swift
@@ -175,8 +175,7 @@ private extension StrigaRegistrationSecondStepViewModel {
         isLoading = true
         Task {
             do {
-                let response = try await service.createUser(data: self.userData)
-                try await service.save(userData: response)
+                try await service.createUser(data: self.userData)
                 await MainActor.run {
                     self.isLoading = false
                 }


### PR DESCRIPTION
## Description of the changes
- Method save has been removed to disable the ability to modify INTERNAL state of `BankTransferService` from outside.
- Method createUser will return only the result (success or fail, without returning any value). The internal state UserData will be managed internally by `BankTransferService`. 
