### PR TITLE
[PWN-8848] Bugfix/pwn 8848 2

### DIFF
--- a/p2p_wallet/Services/Auth/Logout/LogoutService.swift
+++ b/p2p_wallet/Services/Auth/Logout/LogoutService.swift
@@ -6,11 +6,8 @@ protocol LogoutService {
 }
 
 final class LogoutServiceImpl: LogoutService {
-    @Injected private var bankTransferService: BankTransferService
-    @Injected private var userWalletManager: UserWalletManager
-
     func logout() async {
-        await bankTransferService.clearCache()
-        try? await userWalletManager.remove()
+        await Resolver.resolve(BankTransferService.self).clearCache()
+        try? await Resolver.resolve(UserWalletManager.self).remove()
     }
 }


### PR DESCRIPTION
## Link jira to issue
https://p2pvalidator.atlassian.net/browse/PWN-8848

## Description of the changes
- LogoutService starts right after the settings initialized. So the BankTransferService starts immediately when opening the app. This is unexpected behavior.
- Solution: Move injection into function logout itself
